### PR TITLE
Depend on blinky.c, not blinky_final.c

### DIFF
--- a/lab01/Makefile
+++ b/lab01/Makefile
@@ -53,7 +53,7 @@ clean:
 #
 # Rules for building the application
 #
-${COMPILER}/${TARGET}.axf: ${COMPILER}/blinky_final.o
+${COMPILER}/${TARGET}.axf: ${COMPILER}/blinky.o
 ${COMPILER}/${TARGET}.axf: ${COMPILER}/startup_${COMPILER}.o
 
 #


### PR DESCRIPTION
Makefile specifies dependency on a `blinky_final.o`, which does not map to the present file `blinky.c`.

As far as I can tell, this was not an intended obstacle, or "got'cha" of the lab.